### PR TITLE
fix: GHA workflows and cleanup comments

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -3,24 +3,11 @@ on:
     push:
         tags: v*
     workflow_dispatch:
-        # inputs:
-        #     tag:
-        #         type: string
-        #         description: "Commit ID override"
-        #         required: false
 
 
 jobs:
-    # determine-tag:
-    #     runs-on: self-hosted
-    #     steps:
-    #         - name: Determine tag
-    #           run: |
-    #             if [ -n "${{ github.event.inputs.tag }}"]
-
     call-build:
         uses: ./.github/workflows/build.yml
-        # needs: determine-tag
         with:
             tag: ${{ github.ref_name }}
     deploy:

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -22,4 +22,4 @@ jobs:
                 docker container rm vref-test
 
             - name: Start new container
-              run: docker run -d -p 3001:3000 --restart always --name vref-test vref-server:${{ github.ref_name }}
+              run: docker run -d -p 3001:3000 --restart always --name vref-test vref-server:test


### PR DESCRIPTION
Outside of this commit: Set `.env` on the self-hosted runner to set DOCKER_HOST, as the docker socket's location was changed after docker rootless was installed